### PR TITLE
Added the tests directory in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+recursive-include tests
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This patch adds the tests directory as part of the package.
This is so we can construct an rpm in SUSE linux and include it as
part of the distro.  We need to be able to run the tests as part of the
SUSE rpm build.