### PR TITLE
Early load config to allow usage in in internal hooks/plugins and fixtures

### DIFF
--- a/pytest_testconfig.py
+++ b/pytest_testconfig.py
@@ -169,7 +169,7 @@ def pytest_addoption(parser, env=os.environ):
     parser.addini("github", "GitHub issue integration", "args")
 
 
-def pytest_configure(config):
+def pytest_cmdline_main(config):
     """ Call the super and then validate and call the relevant parser for
     the configuration file passed in """
     global py_config


### PR DESCRIPTION
This PR changes the implemented hook from `pytest_configure` to `pytest_cmdline_main`.

The intention here is to load config as soon as possible in the pytest life cycle so code that is initialised before pytest_configure hooks are executed, can make use of it.